### PR TITLE
Set device OSD Name to hostname

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,10 +48,11 @@ checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "cec-dpms"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cec-rs",
  "clap",
+ "hostname",
  "log",
  "signal-hook",
  "simplelog",
@@ -241,6 +242,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "hostname"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9c7c7c8ac16c798734b8a24560c1362120597c40d5e1459f09498f8f6c8f2ba"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows",
 ]
 
 [[package]]
@@ -535,3 +547,86 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ simplelog = { version = "0.11.2", features = ["paris", "ansi_term"] }
 log = '0.4.11'
 signal-hook = "0.3.13"
 clap = { version = "3.0.13", features = ["derive"] }
+hostname = '^0.4'

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,8 +72,10 @@ fn on_log_message(log_message: CecLogMessage) {
 ///
 /// This function gets the system hostname and returns it, or in the case of a
 /// retrieval error, the string "`dummy`".  Although intended for use with CEC
-/// `OSD Name`, it does not truncate the returned string. The string should be
-/// truncated to 14 bytes before use when setting a CEC `OSD Name`.
+/// `OSD Name`, it does not truncate the returned string. The string will be
+/// truncated to 14 bytes by `libcec-sys` (not including C-string trailing null)
+/// when setting a CEC `OSD Name` with `device_name()`.  It's not necessary to
+/// append a trailing null, as this is done by lower-level `libcec` C bindings.
 ///
 /// ## Example
 ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,15 +68,46 @@ fn on_log_message(log_message: CecLogMessage) {
     }
 }
 
-fn get_hostname() -> String {
+/// Returns the hostname of the current system, for use with CEC `OSD Name`.
+///
+/// This function gets the system hostname and returns it, or in the case of a
+/// retrieval error, the string "`dummy`".  Although intended for use with CEC
+/// `OSD Name`, it does not truncate the returned string. The string should be
+/// truncated to 14 bytes before use when setting a CEC `OSD Name`.
+///
+/// ## Example
+///
+/// ```rust
+/// # use std::io;
+/// # fn main() -> io::Result<()> {
+/// let name = get_osd_hostname();
+/// # Ok(())
+/// # }
+/// ```
+///
+/// ## Errors
+///
+/// If the `hostname::get()` function encounters any form of error, the default
+/// string, "`dummy`", will be returned; in practice this is rare to happen.
+///
+/// If the returned hostname contains non-Unicode characters, this is a fatal
+/// error, and the program panics.
+/// This should **_not_** be possible according to Internet Standards:
+/// [RFC 952][1], [RFC 921][2], [RFC 1123][3], and [RFC 3492][4]
+///
+/// [1]: https://www.rfc-editor.org/rfc/rfc952
+/// [2]: https://www.rfc-editor.org/rfc/rfc921
+/// [3]: https://www.rfc-editor.org/rfc/rfc1123
+/// [4]: https://www.rfc-editor.org/info/rfc3492
+fn get_osd_hostname() -> String {
     let hostname_result = hostname::get();
     match hostname_result {
         Err(e) => {
-            debug!("get_hostname: Error getting hostname {}", e);
+            debug!("get_osd_hostname: Error getting hostname {}", e);
             "dummy".to_string() // Just use a default value
         },
         Ok(v) => {
-            debug!("get_hostname: Hostname {:?}", v);
+            debug!("get_osd_hostname: Hostname {:?}", v);
             v.into_string().expect("Hostname should not contain non-Unicode chars")
         },
     }
@@ -91,7 +122,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         &device_path
     );
 
-    let hostname = get_hostname();
+    let hostname = get_osd_hostname();
     info!("Hostname: <b>{:?}</>", hostname);
     let cfg = CecConnectionCfgBuilder::default()
         .port(device_path)


### PR DESCRIPTION
This PR allows for setting `OSD Name` automatically based on the system hostname.

Commit summaries:

- **Set CEC device name to hostname w/default: "dummy"**
- **Cargo.lock: Update w/hostname 0.4.0 + dependencies**
- **Rename get_hostname -> get_osd_hostname & document this function**
- **Document OSD Name max size & libcec C-string behavior**
