### PR TITLE
add systemd template, udev rules & sudoers.d configs

### DIFF
--- a/sudoers.d/70-power-allow-cec-dpms
+++ b/sudoers.d/70-power-allow-cec-dpms
@@ -1,0 +1,1 @@
+%power ALL = NOPASSWD: /usr/bin/pkill * cec-dpms

--- a/systemd/cec-dpms@.service
+++ b/systemd/cec-dpms@.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=cec-dpms for CEC adapter %f
+Documentation=https://github.com/manio/cec-dpms
+After=local-fs.target
+
+[Service]
+Restart=always
+ExecStart=/usr/bin/cec-dpms --input %f
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/cec-dpms@.service
+++ b/systemd/cec-dpms@.service
@@ -2,6 +2,7 @@
 Description=cec-dpms for CEC adapter %f
 Documentation=https://github.com/manio/cec-dpms
 After=local-fs.target
+BindsTo=%i.device
 
 [Service]
 Restart=always

--- a/udev/rules.d/70-pulse-eight-libcec.rules
+++ b/udev/rules.d/70-pulse-eight-libcec.rules
@@ -1,0 +1,8 @@
+# ModemManager and mtp probe should ignore /dev/ttyACM0
+# Allow user control for cec-dpms to power on/off HDMI displays
+ACTION=="add", SUBSYSTEMS=="usb", ATTRS{product}=="CEC Adapter", ENV{ID_MM_DEVICE_IGNORE}="1", ENV{MTP_NO_PROBE}="1", ENV{CEC_ADAPTER}="true"
+ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="2548", ATTRS{idProduct}=="1002", ENV{ID_MM_DEVICE_IGNORE}="1", ENV{MTP_NO_PROBE}="1", ENV{CEC_ADAPTER}="true"
+SUBSYSTEM=="tty", KERNEL=="ttyACM[0-9]*", ATTRS{idVendor}=="2548", ATTRS{idProduct}=="1002", ENV{CEC_ADAPTER}="true"
+SUBSYSTEM=="tty", KERNEL=="ttyACM[0-9]*", ATTRS{idVendor}=="2548", ATTRS{idProduct}=="1001", ENV{CEC_ADAPTER}="true"
+KERNEL=="ttyACM[0-9]*", SUBSYSTEM=="tty", ENV{CEC_ADAPTER}=="true", TAG+="systemd", TAG+="uaccess", TAG+="udev-acl", PROGRAM="/usr/bin/systemd-escape -p --template=cec-dpms@.service $env{DEVNAME}", ENV{SYSTEMD_WANTS}+="%c"
+

--- a/udev/rules.d/70-pulse-eight-libcec.rules
+++ b/udev/rules.d/70-pulse-eight-libcec.rules
@@ -4,5 +4,5 @@ ACTION=="add", SUBSYSTEMS=="usb", ATTRS{product}=="CEC Adapter", ENV{ID_MM_DEVIC
 ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="2548", ATTRS{idProduct}=="1002", ENV{ID_MM_DEVICE_IGNORE}="1", ENV{MTP_NO_PROBE}="1", ENV{CEC_ADAPTER}="true"
 SUBSYSTEM=="tty", KERNEL=="ttyACM[0-9]*", ATTRS{idVendor}=="2548", ATTRS{idProduct}=="1002", ENV{CEC_ADAPTER}="true"
 SUBSYSTEM=="tty", KERNEL=="ttyACM[0-9]*", ATTRS{idVendor}=="2548", ATTRS{idProduct}=="1001", ENV{CEC_ADAPTER}="true"
-KERNEL=="ttyACM[0-9]*", SUBSYSTEM=="tty", ENV{CEC_ADAPTER}=="true", TAG+="systemd", TAG+="uaccess", TAG+="udev-acl", PROGRAM="/usr/bin/systemd-escape -p --template=cec-dpms@.service $env{DEVNAME}", ENV{SYSTEMD_WANTS}+="%c"
+ACTION=="add", KERNEL=="ttyACM[0-9]*", SUBSYSTEM=="tty", ENV{CEC_ADAPTER}=="true", TAG+="systemd", TAG+="uaccess", TAG+="udev-acl", PROGRAM="/usr/bin/systemd-escape -p --template=cec-dpms@.service $env{DEVNAME}", ENV{SYSTEMD_WANTS}+="%c"
 


### PR DESCRIPTION
These example config files have been useful to me, so I thought that I would share.

When used, they enable the following to work:

- udev rules to enable a per-device SystemD service started from template.
  For example, when a USB pulse-eight CEC adapter with device `/dev/ttyACM0` is plugged in:
    - The SystemD template `cec-dpms@.service` is instantiated with `cec-dpms@dev-ttyACM0.service`
    - The service has `BindsTo=dev-ttyACM0.device` so it will shutdown when the device is unplugged
- `sudoers.d` config to allow users in the `power` group to send signals via `/usr/bin/pkill` to `cec-dpms` without a password prompt
  - This enables signaling of the system-level service without a password (e.g. from Sway keybinds, `swayidle`, or other integrations running as the user)

#### Changes:

- **systemd: Add template unit for use with udev rules**  
- **udev: Add example udev rules to launch systemd template unit per-device**
- **sudoers.d: Add example sudoers rules to allow power group to signal cec-dpms**
- **systemd: Bind template unit to lifecycle of CEC adapter device instance**
  This allows for shutdown of the service on USB CEC adapter unplug
- **udev: Limit SystemD .wants rule trigger to action: add**
  