### PR TITLE
Thread-local storage global Arc CEC connection handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,6 +161,7 @@ dependencies = [
 name = "cec-dpms"
 version = "0.1.1"
 dependencies = [
+ "arrayvec",
  "cec-rs",
  "clap",
  "hostname",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ log = '0.4.11'
 signal-hook = "0.3.17"
 clap = { version = "3.0.13", features = ["derive"] }
 hostname = '^0.4'
+arrayvec = '0.7.1'

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,10 @@ use cec_rs::{
     CecDeviceType, CecDeviceTypeVec, CecLogMessage, CecLogicalAddress, CecOpcode,
 };
 
+use std::sync::atomic::AtomicUsize;
+
+static GLOBAL_THREAD_COUNT: AtomicUsize = AtomicUsize::new(0);
+
 #[derive(Parser, Debug)]
 #[clap(version, about, long_about = None)]
 struct Args {
@@ -56,6 +60,12 @@ fn on_command_received(command: CecCommand) {
         "onCommandReceived: opcode: {:?}, initiator: {:?}",
         command.opcode, command.initiator
     );
+    // Note that Relaxed ordering doesn't synchronize anything
+    // except the global thread counter itself.
+    let old_thread_count = GLOBAL_THREAD_COUNT.fetch_add(1, Ordering::Relaxed);
+    // Note that this number may not be true at the moment of printing
+    // because some other thread may have changed static value already.
+    debug!("live threads: {}", old_thread_count + 1);
 
     CONNECTION.with(|connection| {
         debug!(
@@ -129,6 +139,7 @@ fn on_command_received(command: CecCommand) {
                 }
             }
     }
+    GLOBAL_THREAD_COUNT.fetch_sub(1, Ordering::Relaxed);
 })
 }
 
@@ -246,6 +257,8 @@ fn initialize_connection() -> Option<()> {
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
+    let old_thread_count = GLOBAL_THREAD_COUNT.fetch_add(1, Ordering::Relaxed);
+    debug!("live threads at start of main(): {}", old_thread_count + 1);
     let args = Args::parse();
     logging_init(args.debug);
     let device_path = args.input.unwrap().into_os_string().into_string().unwrap();
@@ -303,10 +316,14 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
     })?;
 
+    let last_thread_count = &GLOBAL_THREAD_COUNT.load(Ordering::Relaxed);
+    debug!("live threads at start of main(): {}", last_thread_count);
     info!("Waiting for signals...");
     loop {
         if usr1.load(Ordering::Relaxed) {
             info!("<b><green>USR1</>: powering <b>ON</>");
+            let last_thread_count = &GLOBAL_THREAD_COUNT.load(Ordering::Relaxed);
+            debug!("live threads at USR1 handler start: {}", last_thread_count);
             usr1.store(false, Ordering::Relaxed);
             // This apparently set active source to Tv??
             // let _ = connection.send_power_on_devices(CecLogicalAddress::Tv);

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,8 +12,8 @@ use std::{thread, time};
 use arrayvec::ArrayVec;
 extern crate cec_rs;
 use cec_rs::{
-    CecCommand, CecConnection, CecConnectionCfg, CecConnectionCfgBuilder, CecDatapacket,
-    CecDeviceType, CecDeviceTypeVec, CecLogMessage, CecLogicalAddress, CecOpcode,
+    CecCommand, CecConnection, CecConnectionCfgBuilder, CecDatapacket, CecDeviceType,
+    CecDeviceTypeVec, CecLogMessage, CecLogicalAddress, CecOpcode,
 };
 
 use std::sync::atomic::AtomicUsize;
@@ -67,13 +67,14 @@ fn on_command_received(command: CecCommand) {
     // because some other thread may have changed static value already.
     debug!("live threads: {}", old_thread_count + 1);
 
-    CONNECTION.with(|connection| {
+    THREAD_CONNECTION.with(|connection| {
         debug!(
             "onCommandReceived: opcode type: {:?}",
             std::any::type_name_of_val(&command.opcode)
         );
         debug!("onCommandReceived: try to borrow the connection: {:?}", std::any::type_name_of_val(&connection));
-        if let Some(conn) = connection.borrow().as_ref() {
+        // Use the static CONNECTION variable instead of the thread-local one
+        if let Some(Some(conn)) = CONNECTION.get() {
             debug!(
                 "onCommandReceived: Connection successfully borrowed from thread-local storage: {:?}",
                 std::any::type_name_of_val(&conn)
@@ -204,56 +205,9 @@ fn get_osd_hostname() -> String {
     }
 }
 
+static CONNECTION: std::sync::OnceLock<Option<Arc<CecConnection>>> = std::sync::OnceLock::new();
 thread_local! {
-    static CONNECTION: RefCell<Option<CecConnection>> = RefCell::new(None);
-    static CONNECTION_CONFIG: RefCell<Option<CecConnectionCfg>> = RefCell::new(None);
-}
-
-/// Initializes a `CecConnection` from `CONNECTION_CONFIG` and stores it in
-/// thread-local storage as `CONNECTION`
-///
-/// This function gets the `CecConnectionCfg` from thread-local storage
-/// variable: `CONNECTION_CONFIG`.
-///
-/// ## Example
-///
-/// ```rust
-/// use std::io;
-/// fn main() -> io::Result<()> {
-///   match initialize_connection() {
-///     Some(()) => { Ok(()) }
-///     None => { Err("Could not open CEC connection") }
-///   }
-/// }
-/// ```
-///
-/// ## Errors
-///
-/// None - If an error was encountered opening the CEC connection, then `None`
-///        is returned.
-fn initialize_connection() -> Option<()> {
-    CONNECTION.with(|conn| {
-        // Get mutable access to the thread_local RefCell contents and set it
-        CONNECTION_CONFIG.with(|opt_config| {
-            if let Some(cfg) = opt_config.borrow_mut().take() {
-                match cfg.open() {
-                    Ok(c) => {
-                        info!("Successfully opened CEC connection");
-                        *conn.borrow_mut() = Some(c);
-                        Some(())
-                    }
-                    Err(e) => {
-                        error!("Failed to initialize CEC connection: {:?}", e);
-                        *conn.borrow_mut() = None;
-                        None
-                    }
-                }
-            } else {
-                error!("Failed to get mutable reference to thread-local CecConnectionCfg");
-                None
-            }
-        })
-    })
+    static THREAD_CONNECTION: RefCell<Option<Arc<CecConnection>>> = RefCell::new(None);
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -277,10 +231,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         .device_types(CecDeviceTypeVec::new(CecDeviceType::PlaybackDevice))
         .build()
         .unwrap();
-    CONNECTION_CONFIG.with(|config| {
-        // store it in thread-local RefCell's value
-        *config.borrow_mut() = Some(cfg);
-    });
     // Setup signal handling flags
     let usr1 = Arc::new(AtomicBool::new(false));
     let usr2 = Arc::new(AtomicBool::new(false));
@@ -290,31 +240,41 @@ fn main() -> Result<(), Box<dyn Error>> {
     signal_hook::flag::register(SIGTERM, Arc::clone(&terminate))?;
     signal_hook::flag::register(SIGINT, Arc::clone(&terminate))?;
 
-    // Initialize CecConnection and store it in thread-local CONNECTION
-    initialize_connection();
+    // Open CecConnection directly
+    let connection = match cfg.open() {
+        Ok(conn) => {
+            info!("Successfully opened CEC connection");
+            Some(Arc::new(conn))
+        }
+        Err(e) => {
+            error!("Failed to open CEC connection: {:?}", e);
+            None
+        }
+    };
 
-    // Sharing same CEC connection with callback function threads, so only borrow it when needed
-    CONNECTION.with(|conn| {
-        // Get mutable access to the thread_local RefCell contents and set it
-        // *conn.borrow_mut() = cfg.open().ok();
-        // connection = cfg.open().unwrap();
-        if let Some(connection) = conn.borrow().as_ref() {
+    // Store in static for access from callbacks and main thread
+    let _ = CONNECTION.set(connection.clone());
+
+    // Also store in thread-local for main thread use
+    THREAD_CONNECTION.with(|tconn| {
+        *tconn.borrow_mut() = connection.clone();
+    });
+
+    // Verify connection is working
+    let _res = connection
+        .map(|conn| {
             info!(
                 "Am I active source? <b>{:?}</>",
-                connection.is_active_source(CecLogicalAddress::Playbackdevice1)
+                conn.is_active_source(CecLogicalAddress::Playbackdevice1)
             );
-            info!("Active source: <b>{:?}</>", connection.get_active_source());
+            info!("Active source: <b>{:?}</>", conn.get_active_source());
             Ok(()) as Result<(), Box<dyn Error>>
-        } else {
+        })
+        .unwrap_or_else(|| {
             let err_msg = "Failed to open CEC connection";
             error!("{}", err_msg);
             Err(err_msg.to_string().into())
-            // Err(Box::new(std::io::Error::new(
-            //     std::io::ErrorKind::Other,
-            //     err_msg,
-            // )))
-        }
-    })?;
+        });
 
     let last_thread_count = &GLOBAL_THREAD_COUNT.load(Ordering::Relaxed);
     debug!("live threads at start of main(): {}", last_thread_count);
@@ -327,7 +287,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             usr1.store(false, Ordering::Relaxed);
             // This apparently set active source to Tv??
             // let _ = connection.send_power_on_devices(CecLogicalAddress::Tv);
-            CONNECTION.with(|conn| {
+            let _res = THREAD_CONNECTION.with(|conn| {
                 if let Some(connection) = conn.borrow().as_ref() {
                     let power_on_devices_result =
                         connection.send_power_on_devices(CecLogicalAddress::Tv);
@@ -363,12 +323,12 @@ fn main() -> Result<(), Box<dyn Error>> {
                     error!("{}", err_msg);
                     Err(err_msg.to_string().into())
                 }
-            })?;
+            });
         }
         if usr2.load(Ordering::Relaxed) {
             info!("<b><green>USR2</>: powering <b>OFF</>");
             usr2.store(false, Ordering::Relaxed);
-            CONNECTION.with(|conn| {
+            THREAD_CONNECTION.with(|conn| {
                 // Get mutable access to the thread_local RefCell contents and set it
                 // *conn.borrow_mut() = cfg.open().ok();
                 if let Some(connection) = conn.borrow().as_ref() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,16 +2,18 @@ use clap::Parser;
 use hostname;
 use signal_hook::{consts::SIGINT, consts::SIGTERM, consts::SIGUSR1, consts::SIGUSR2};
 use simplelog::*;
+use std::cell::RefCell;
 use std::error::Error;
 use std::ffi::CString;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::{thread, time};
 
+use arrayvec::ArrayVec;
 extern crate cec_rs;
 use cec_rs::{
-    CecCommand, CecConnectionCfgBuilder, CecDeviceType, CecDeviceTypeVec, CecLogMessage,
-    CecLogicalAddress,
+    CecCommand, CecConnection, CecConnectionCfg, CecConnectionCfgBuilder, CecDatapacket,
+    CecDeviceType, CecDeviceTypeVec, CecLogMessage, CecLogicalAddress, CecOpcode,
 };
 
 #[derive(Parser, Debug)]
@@ -54,6 +56,80 @@ fn on_command_received(command: CecCommand) {
         "onCommandReceived: opcode: {:?}, initiator: {:?}",
         command.opcode, command.initiator
     );
+
+    CONNECTION.with(|connection| {
+        debug!(
+            "onCommandReceived: opcode type: {:?}",
+            std::any::type_name_of_val(&command.opcode)
+        );
+        debug!("onCommandReceived: try to borrow the connection: {:?}", std::any::type_name_of_val(&connection));
+        if let Some(conn) = connection.borrow().as_ref() {
+            debug!(
+                "onCommandReceived: Connection successfully borrowed from thread-local storage: {:?}",
+                std::any::type_name_of_val(&conn)
+            );
+            match command.opcode {
+                CecOpcode::GiveDevicePowerStatus => {
+                    debug!(
+                        "onCommandReceived: Got a GiveDevicePowerStatus command!!: opcode: {:?}, initiator: {:?}, destination: {:?}, ack: {:?}, eom: {:?}, parameters: {:?}, opcode_set?: {:?}, transmit_timeout: {:?}",
+                        command.opcode, command.initiator, command.destination, command.ack, command.eom, command.parameters, command.opcode_set, command.transmit_timeout
+                    );
+
+                    let mut a = ArrayVec::new();
+                    a.push(0x00); // CEC_POWER_STATUS_ON
+                    let packet = CecDatapacket(a);
+
+                    let _ = conn.transmit(CecCommand {
+                        initiator: CecLogicalAddress::Playbackdevice1,
+                        destination: command.initiator,
+                        opcode: CecOpcode::ReportPowerStatus,
+                        parameters: packet,
+                        eom: true,
+                        ack: false,
+                        opcode_set: false,
+                        transmit_timeout: time::Duration::from_secs(5),
+                    });
+                }
+                CecOpcode::ReportPowerStatus => {
+                    debug!(
+                        "onCommandReceived: Got a ReportPowerStatus command!!: opcode: {:?}, initiator: {:?}, destination: {:?}, ack: {:?}, eom: {:?}, parameters: {:?}, opcode_set?: {:?}, transmit_timeout: {:?}",
+                        command.opcode, command.initiator, command.destination, command.ack, command.eom, command.parameters, command.opcode_set, command.transmit_timeout
+                    );
+                }
+                _ => {
+                    debug!(
+                        "onCommandReceived: Unknown command: opcode: {:?}, initiator: {:?}, destination: {:?}",
+                        command.opcode, command.initiator, command.destination
+                    );
+                }
+            }
+        }
+        else {
+            debug!("<b><red>Error:</> Could not borrow the connection: {:?}", std::any::type_name_of_val(&connection));
+
+            debug!("<b><red>Debug:</> RefCell wrapper type: {}", std::any::type_name_of_val(&connection));
+            // Get the contents of RefCell
+            let borrowed = connection.borrow();
+            debug!("<b><red>Debug:</> After borrow() is_some()??: {:#?} (type: {})",
+                borrowed.is_some(),
+                std::any::type_name_of_val(&borrowed)
+            );
+
+            // Look at the Option value inside
+            match *borrowed {
+                Some(ref cec_conn) => {
+                    debug!("Connection exists (type: {}) with:", std::any::type_name_of_val(cec_conn));
+                    debug!("  - Logical addresses: {:?}", cec_conn.get_logical_addresses());
+                    debug!("  - Active source: {:?}", cec_conn.get_active_source());
+                    let foo = cec_conn.is_active_source(CecLogicalAddress::Playbackdevice1);
+                    debug!("  - Is Playbackdevice1 active source?: {:#?}", foo);
+                },
+                None => {
+                    debug!("Connection is None!");
+                }
+            }
+    }
+})
 }
 
 fn on_log_message(log_message: CecLogMessage) {
@@ -117,6 +193,58 @@ fn get_osd_hostname() -> String {
     }
 }
 
+thread_local! {
+    static CONNECTION: RefCell<Option<CecConnection>> = RefCell::new(None);
+    static CONNECTION_CONFIG: RefCell<Option<CecConnectionCfg>> = RefCell::new(None);
+}
+
+/// Initializes a `CecConnection` from `CONNECTION_CONFIG` and stores it in
+/// thread-local storage as `CONNECTION`
+///
+/// This function gets the `CecConnectionCfg` from thread-local storage
+/// variable: `CONNECTION_CONFIG`.
+///
+/// ## Example
+///
+/// ```rust
+/// use std::io;
+/// fn main() -> io::Result<()> {
+///   match initialize_connection() {
+///     Some(()) => { Ok(()) }
+///     None => { Err("Could not open CEC connection") }
+///   }
+/// }
+/// ```
+///
+/// ## Errors
+///
+/// None - If an error was encountered opening the CEC connection, then `None`
+///        is returned.
+fn initialize_connection() -> Option<()> {
+    CONNECTION.with(|conn| {
+        // Get mutable access to the thread_local RefCell contents and set it
+        CONNECTION_CONFIG.with(|opt_config| {
+            if let Some(cfg) = opt_config.borrow_mut().take() {
+                match cfg.open() {
+                    Ok(c) => {
+                        info!("Successfully opened CEC connection");
+                        *conn.borrow_mut() = Some(c);
+                        Some(())
+                    }
+                    Err(e) => {
+                        error!("Failed to initialize CEC connection: {:?}", e);
+                        *conn.borrow_mut() = None;
+                        None
+                    }
+                }
+            } else {
+                error!("Failed to get mutable reference to thread-local CecConnectionCfg");
+                None
+            }
+        })
+    })
+}
+
 fn main() -> Result<(), Box<dyn Error>> {
     let args = Args::parse();
     logging_init(args.debug);
@@ -136,7 +264,11 @@ fn main() -> Result<(), Box<dyn Error>> {
         .device_types(CecDeviceTypeVec::new(CecDeviceType::PlaybackDevice))
         .build()
         .unwrap();
-    let connection = cfg.open().unwrap();
+    CONNECTION_CONFIG.with(|config| {
+        // store it in thread-local RefCell's value
+        *config.borrow_mut() = Some(cfg);
+    });
+    // Setup signal handling flags
     let usr1 = Arc::new(AtomicBool::new(false));
     let usr2 = Arc::new(AtomicBool::new(false));
     let terminate = Arc::new(AtomicBool::new(false));
@@ -145,22 +277,100 @@ fn main() -> Result<(), Box<dyn Error>> {
     signal_hook::flag::register(SIGTERM, Arc::clone(&terminate))?;
     signal_hook::flag::register(SIGINT, Arc::clone(&terminate))?;
 
-    info!("Active source: <b>{:?}</>", connection.get_active_source());
+    // Initialize CecConnection and store it in thread-local CONNECTION
+    initialize_connection();
+
+    // Sharing same CEC connection with callback function threads, so only borrow it when needed
+    CONNECTION.with(|conn| {
+        // Get mutable access to the thread_local RefCell contents and set it
+        // *conn.borrow_mut() = cfg.open().ok();
+        // connection = cfg.open().unwrap();
+        if let Some(connection) = conn.borrow().as_ref() {
+            info!(
+                "Am I active source? <b>{:?}</>",
+                connection.is_active_source(CecLogicalAddress::Playbackdevice1)
+            );
+            info!("Active source: <b>{:?}</>", connection.get_active_source());
+            Ok(()) as Result<(), Box<dyn Error>>
+        } else {
+            let err_msg = "Failed to open CEC connection";
+            error!("{}", err_msg);
+            Err(err_msg.to_string().into())
+            // Err(Box::new(std::io::Error::new(
+            //     std::io::ErrorKind::Other,
+            //     err_msg,
+            // )))
+        }
+    })?;
+
     info!("Waiting for signals...");
     loop {
         if usr1.load(Ordering::Relaxed) {
             info!("<b><green>USR1</>: powering <b>ON</>");
             usr1.store(false, Ordering::Relaxed);
-            let _ = connection.set_active_source(CecDeviceType::PlaybackDevice);
+            // This apparently set active source to Tv??
+            // let _ = connection.send_power_on_devices(CecLogicalAddress::Tv);
+            CONNECTION.with(|conn| {
+                if let Some(connection) = conn.borrow().as_ref() {
+                    let power_on_devices_result =
+                        connection.send_power_on_devices(CecLogicalAddress::Tv);
+                    match power_on_devices_result {
+                        Ok(()) => {
+                            info!("<b><green>Success!</> Sent power on command to Tv");
+                        }
+                        Err(e) => {
+                            error!(
+                                "<b><red>Error:</> Failed to send power on devices command! {:?}",
+                                e
+                            );
+                        }
+                    }
+                    //the following call is working the same on my samsung, idk what is more proper:
+                    let set_active_source_result: Result<(), cec_rs::CecConnectionResultError> =
+                        connection.set_active_source(CecDeviceType::PlaybackDevice);
+                    match set_active_source_result {
+                        Ok(o) => {
+                            info!("<b><green>Success!</> Set active source {:?}", o);
+                        }
+                        Err(e) => {
+                            error!("<b><red>Error:</> Failed to set active source {:?}!", e);
+                        }
+                    }
+                    info!(
+                        "<i>connection.get_logical_addresses()</i> = {:?}",
+                        connection.get_logical_addresses()
+                    );
+                    Ok(()) as Result<(), Box<dyn Error>>
+                } else {
+                    let err_msg = "Failed to open CEC connection";
+                    error!("{}", err_msg);
+                    Err(err_msg.to_string().into())
+                }
+            })?;
         }
         if usr2.load(Ordering::Relaxed) {
             info!("<b><green>USR2</>: powering <b>OFF</>");
             usr2.store(false, Ordering::Relaxed);
-            if connection.get_active_source() == CecLogicalAddress::Playbackdevice1 {
-                let _ = connection.send_standby_devices(CecLogicalAddress::Tv);
-            } else {
-                info!("<i>reguest ignored</>: we are not an active source");
-            }
+            CONNECTION.with(|conn| {
+                // Get mutable access to the thread_local RefCell contents and set it
+                // *conn.borrow_mut() = cfg.open().ok();
+                if let Some(connection) = conn.borrow().as_ref() {
+                    info!(
+                        "<b><green>Active source:</> <b>{:?}</>",
+                        connection.get_active_source()
+                    );
+                    if connection.get_active_source() == CecLogicalAddress::Playbackdevice1 {
+                        let _ = connection.send_standby_devices(CecLogicalAddress::Tv);
+                    } else {
+                        info!("<i>reguest ignored</>: we are not an active source");
+                    }
+                    Ok(()) as Result<(), Box<dyn Error>>
+                } else {
+                    let err_msg = "Failed to open CEC connection";
+                    error!("{}", err_msg);
+                    Err(err_msg.to_string().into())
+                }
+            })?;
         }
         if terminate.load(Ordering::Relaxed) {
             info!("Terminating");
@@ -168,5 +378,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
         thread::sleep(time::Duration::from_secs(1));
     }
-    Ok(())
+    Ok(()) as Result<(), Box<dyn Error>>
+
+    // Ok(())
 }


### PR DESCRIPTION
This is a bit of an overall refactor to use a singleton `CecConnection` which can be shared across threads.

The rationale behind doing this is to be able to share the `CecConnection` across the FFI boundary to any callback handlers (e.g. functions passed to `CecConnectionCfg.command_received_callback()`).  These callback functions (e.g. `on_command_received`) were previously not able to utilize the `CecConnection` attached to the shared hardware CEC adapter.  So they could not use it to respond to any unhandled CEC commands (`libcec` does respond automatically to most, but there are some exceptions).

In any case, the underlying lower level `libcec_sys` and `libcec` C code (used through FFI) will spawn any callback functions in separate threads.  That poses the issue of how to share a `CecConnection` object in Rust across this boundary.  Using this singleton pattern works and passes Rust's borrow and type checking, thanks to [`Arc`][1] being a thread-safe reference-counting pointer.

This should enable us to handle responding to CEC commands in the future within the `on_command_received()` callback.

#### Changes:

- **cargo: Add arrayvec 0.7.1**
- **cargo fmt & Initial implementation of thread-local storage CecConnection handling**
- **debug: Add global atomic thread counter**
- **connection: Refactor `conn` handling w/static `OnceLock<Option<Arc<CecConnection>>>`**
  Thread-local wasn't working to truly share the _same_ connection across threads
  because the mutable borrow was failing. To complicate matters, `CecConnection`
  and `CecConnectionCfg` don't implement `Copy` or `Clone` traits, nor are they `Sync`.
  
  `Option<Arc<..>>` implements the `Clone` trait, so relying on this to store an
  `Arc` to be shared across threads works.  Add to this using `OnceLock` for the
  global `static` variable to be initialized only once.  Thus, we create a singleton
  pattern: the connection initialized in `main()` once becomes the single shared
  connection instance, for use in the `on_command_received()` handler function
  across `libcec` threads.
  
  Note: `LazyLock` was tried, but the initializer proc/closure was always failing to
  borrow and reliably access thread-local variables. Since initialization may have
  been called from multiple threads, any dereferencing call will block the calling
  thread if another initialization routine is currently running.
  
  The way that lower-level `cec_rs` and `libcec-sys` libraries implement the callback
  functions (e.g. `ICECCallbacks::commandReceived`) is to execute them in another
  thread.  However, due to the way that Rust type & borrow checked code is run,
  we would otherwise lose access to the same `CecConnection` object across the ffi
  boundary:
  
      Rust main() -> libcec ffi C code -> thread(s?) -> on_command_received()
  
  Using this `OnceLock` singleton pattern with `Option<Arc<...>>` seems to work.
  
[1]: https://doc.rust-lang.org/std/sync/struct.Arc.html